### PR TITLE
Fix error handling for multiple validations

### DIFF
--- a/app/assets/javascripts/turboboost.js.coffee
+++ b/app/assets/javascripts/turboboost.js.coffee
@@ -15,6 +15,7 @@ disableForm = ($form) ->
 
 turboboostFormError = (e, errors) ->
   return if !Turboboost.insertErrors
+  errors = tryJSONParse errors 
   errors = [Turboboost.defaultError] if !errors.length
   $form = $(e.target)
   $el = $form.find(errID)
@@ -36,7 +37,7 @@ turboboostComplete = (e, resp) ->
 
   if resp.status in [400..599]
     enableForm $el if isForm
-    $el.trigger "turboboost:error", tryJSONParse resp.responseText
+    $el.trigger "turboboost:error", resp.responseText
 
   $el.trigger "turboboost:complete"
 


### PR DESCRIPTION
Used this to fix an issue where turboboost was only showing the first validation error if there were multiple listed in the response.
