### PR TITLE
Support the rails 4.2 (4.2.0beta4 at time of commit)

### DIFF
--- a/lib/turboboost.rb
+++ b/lib/turboboost.rb
@@ -83,7 +83,12 @@ module Turboboost
       # set flash for turbo redirect headers
       turboboost_flash = _turboboost_get_flash_messages(response_status_and_flash)
 
-      self.location = _compute_redirect_to_location(options)
+      if Rails.version < "4.2"
+        self.location = _compute_redirect_to_location(options)
+      else
+        self.location = _compute_redirect_to_location(request, options)
+      end
+
       head :ok, "X-Flash" => turboboost_flash.to_json
 
       flash.update(turboboost_flash) # set flash for rendered view


### PR DESCRIPTION
Rails >= 4.2 has changed the method arity of
_compute_redirect_to_location from (options) to
(*args). The validation inside then expects two
parameters: request, options. This commit handles
these changes.

[Rails 4.2 _compute_redirect_to_location source](https://github.com/rails/rails/blob/2090615d39c071c9eb25e715275eb79f3f9b6266/actionpack/lib/action_controller/metal/redirecting.rb#L79)

Instead of checking the Rails.version, we could check the method arity:

``` ruby
if method(: _compute_redirect_to_location).arity == -1
  self.location = _compute_redirect_to_location(request, options)
else ...
```

I was torn, but went with the version check because it was simpler.
