### PR TITLE
Trigger complete even if form was replaced

### DIFF
--- a/app/assets/javascripts/turboboost/turboboost.js.coffee
+++ b/app/assets/javascripts/turboboost/turboboost.js.coffee
@@ -54,12 +54,15 @@ turboboostComplete = (e, resp) ->
       return
     else
       enableForm $el if isForm and Turboboost.handleFormDisabling
-      maybeInsertSuccessResponseBody(resp)
+      $inserted = maybeInsertSuccessResponseBody(resp)
   else if 400 <= resp.status  < 600
     enableForm $el if isForm and Turboboost.handleFormDisabling
     $el.trigger "turboboost:error", resp.responseText
 
-  $el.trigger "turboboost:complete"
+  if $.contains(document.documentElement, $el[0])
+    $el.trigger "turboboost:complete"
+  else
+    $inserted.trigger "turboboost:complete"
 
 turboboostBeforeSend = (e, xhr, settings) ->
   xhr.setRequestHeader('X-Turboboost', '1')


### PR DESCRIPTION
If maybeInsertSuccessResponseBody replaces the turboboosted form (required for showing server-side validation errors) then the turboboost:complete event will not be triggered on the form that is actually now in the dom



