### PR TITLE
fixed missing trigger events when using rermotipart

### DIFF
--- a/app/assets/javascripts/turboboost/turboboost.js.coffee
+++ b/app/assets/javascripts/turboboost/turboboost.js.coffee
@@ -46,8 +46,9 @@ turboboostFormError = (e, errors) ->
 turboboostComplete = (e, resp) ->
   $el = $(@)
   isForm = @nodeName is "FORM"
+  status = parseInt(resp.status)
 
-  if 200 <= resp.status < 300
+  if 200 <= status < 300
     $el.trigger "turboboost:success", tryJSONParse resp.getResponseHeader('X-Flash')
     $el.find(errID).remove() if Turboboost.insertErrors and isForm
     if (location = resp.getResponseHeader('Location')) and !$el.attr('data-no-turboboost-redirect')
@@ -58,7 +59,7 @@ turboboostComplete = (e, resp) ->
     else
       enableForm $el if isForm and Turboboost.handleFormDisabling
       $inserted = maybeInsertSuccessResponseBody(resp)
-  else if 400 <= resp.status  < 600
+  else if 400 <= status  < 600
     enableForm $el if isForm and Turboboost.handleFormDisabling
     $el.trigger "turboboost:error", resp.responseText
 


### PR DESCRIPTION
Hi,

I found in some cases that status returns string type, for example, response from remotipart.
This causes incorrect condition and not trigger events.
convert to integer to fix it.